### PR TITLE
Fix DST bug and refactor internals

### DIFF
--- a/gen/jp_generator.go
+++ b/gen/jp_generator.go
@@ -24,14 +24,11 @@ var filename = flag.String("output", "nholidays/jp/schedule.go", "output file na
 func main() {
 	f, err := os.Open("nholidays/jp/national_holidays.csv")
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	r := csv.NewReader(f)
 
-	var (
-		h      []*Holiday
-		isSkip bool
-	)
+	var h []*Holiday
 
 	for i := 0; ; i++ {
 		record, err := r.Read()
@@ -39,33 +36,19 @@ func main() {
 			break
 		}
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 		if i == 0 {
 			continue
 		}
 
-		var holiday Holiday
-		for i, v := range record {
-			switch i {
-			case 0:
-				t, err := time.Parse("2006/1/2", v)
-				if err != nil {
-					panic(err)
-				}
-				tmp := t.Format("2006-01-02")
-				if tmp >= "2000-01-01" {
-					holiday.Date = t.Format("2006-01-02")
-					isSkip = false
-				} else {
-					isSkip = true
-				}
-			case 1:
-				if !isSkip {
-					holiday.Name = v
-					h = append(h, &holiday)
-				}
-			}
+		t, err := time.Parse("2006/1/2", record[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		date := t.Format("2006-01-02")
+		if date >= "2000-01-01" {
+			h = append(h, &Holiday{Date: date, Name: record[1]})
 		}
 	}
 

--- a/goholiday.go
+++ b/goholiday.go
@@ -51,11 +51,6 @@ func (g *Goholiday) SetUniqueHolidays(ts []time.Time) {
 	}
 }
 
-func (g *Goholiday) isUniqueHoliday(t time.Time) bool {
-	_, exist := g.uniqueHolidays[t.Format(dateFormat)]
-	return exist
-}
-
 func (g *Goholiday) IsBusinessDay(t time.Time) bool {
 	return !g.IsHoliday(t)
 }

--- a/goholiday.go
+++ b/goholiday.go
@@ -27,7 +27,17 @@ func (g *Goholiday) IsNationalHoliday(t time.Time) bool {
 }
 
 func (g *Goholiday) IsHoliday(t time.Time) bool {
-	return g.isWeekdayHoliday(t) || g.IsNationalHoliday(t) || g.isUniqueHoliday(t)
+	if g.isWeekdayHoliday(t) {
+		return true
+	}
+	dateKey := t.Format(dateFormat)
+	if _, exist := g.schedule.GetNationalHolidays()[dateKey]; exist {
+		return true
+	}
+	if _, exist := g.uniqueHolidays[dateKey]; exist {
+		return true
+	}
+	return false
 }
 
 func (g *Goholiday) isWeekdayHoliday(t time.Time) bool {
@@ -59,9 +69,8 @@ func (g *Goholiday) BusinessDaysAfter(t time.Time, bds int) time.Time {
 }
 
 func (g *Goholiday) travelBusinessDays(t time.Time, bds int, course int) time.Time {
-	duration := time.Hour * 24 * time.Duration(course)
 	for tbds := 0; tbds != bds; {
-		if t = t.Add(duration); !g.IsHoliday(t) {
+		if t = t.AddDate(0, 0, course); !g.IsHoliday(t) {
 			tbds++
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix potential DST bug in `travelBusinessDays` by using `time.AddDate` instead of `time.Add(24h)`
- Optimize `IsHoliday` to avoid redundant `t.Format()` calls
- Simplify CSV parsing logic and unify error handling in `jp_generator.go`

## Details
### travelBusinessDays DST fix
`time.Add(time.Hour * 24)` can produce incorrect results at daylight saving time boundaries (23h
or 25h days). Replaced with `time.AddDate(0, 0, 1)` which always advances exactly one calendar
day.

### IsHoliday optimization
Previously `t.Format(dateFormat)` was called separately in `IsNationalHoliday` and
`isUniqueHoliday`. Now formatted once and reused for both map lookups.

### jp_generator simplification
Removed `isSkip` flag and `switch`-based column iteration. Replaced `panic` with `log.Fatal` for
consistency.